### PR TITLE
Updates to IntelliSense

### DIFF
--- a/opuxl_addin/Opuxl/OpuxlClassLibrary/packages.config
+++ b/opuxl_addin/Opuxl/OpuxlClassLibrary/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ExcelDna.Integration" version="0.33.9" targetFramework="net452" />
-  <package id="ExcelDna.IntelliSense" version="0.1.10-beta10" targetFramework="net452" />
+  <package id="ExcelDna.IntelliSense" version="1.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="UIAComWrapper" version="1.1.0.14" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The latest IntelliSense changed significantly (removal of the UI Automation dependency).
This should fix freezing auto-completion in Excel2016 with 32bit.